### PR TITLE
remove (broken) deps badge as (beta) service no longer available. 😞

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![Build Status](https://img.shields.io/travis/dwyl/hits-elixir/master.svg?style=flat-square)](https://travis-ci.org/dwyl/hits-elixir)
 [![Inline docs](http://inch-ci.org/github/dwyl/hits-elixir.svg?style=flat-square)](http://inch-ci.org/github/dwyl/hits-elixir)
 [![codecov.io](https://img.shields.io/codecov/c/github/dwyl/hits-elixir/master.svg?style=flat-square)](http://codecov.io/github/dwyl/hits-elixir?branch=master)
-[![Deps Status](https://beta.hexfaktor.org/badge/all/github/dwyl/hits-elixir.svg?style=flat-square)](https://beta.hexfaktor.org/github/dwyl/hits-elixir)
 [![HitCount](http://hits.dwyl.io/dwyl/hits-elixir.svg)](https://github.com/dwyl/hits-elixir)
 
 </div>


### PR DESCRIPTION
tired of seeing this broken "Deps Status" badge:
![image](https://user-images.githubusercontent.com/194400/57158625-c7de2280-6ddb-11e9-8f42-273f70e686f3.png)
